### PR TITLE
fix_err: update pom.xml to solve javax.xml.bind package missed in mvn install

### DIFF
--- a/coap-jmeter/pom.xml
+++ b/coap-jmeter/pom.xml
@@ -41,7 +41,12 @@
             <artifactId>californium-core</artifactId>
             <version>2.0.0-M5</version>
         </dependency>
-
+        
+	<dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
+	</dependency>
 
         <dependency>
             <groupId>org.eclipse.californium</groupId>

--- a/coap-jmeter/pom.xml
+++ b/coap-jmeter/pom.xml
@@ -42,11 +42,11 @@
             <version>2.0.0-M5</version>
         </dependency>
         
-	<dependency>
+        <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
             <version>2.3.0</version>
-	</dependency>
+        </dependency>
 
         <dependency>
             <groupId>org.eclipse.californium</groupId>


### PR DESCRIPTION
the javax.xml.bind package was removed for the java which versions later than 1.8